### PR TITLE
Implement the Mission Statement Section of the home page.

### DIFF
--- a/src/pages/Home/Home.css
+++ b/src/pages/Home/Home.css
@@ -126,6 +126,43 @@ a:active { text-decoration: none; }
         background-color: #C4C4C4;
         margin-top: 1px;
     }
+} 
+
+/* mission statement section */
+.mission_statement_title {
+    text-align: center;
+    font-weight: 700;
+    font-size: 2em;
+    letter-spacing: 0.035em;
+    padding-top: 4em;
+}
+
+.horizontal_divider {
+    border-top: 4px solid #77B0F3;
+    width: 6.5em;
+    margin-top: -0.50em;
+    margin-bottom: 1.25em;
+}
+
+.mission_statement {
+    margin-bottom: 3em;
+    text-align: center;
+}
+
+.mission_img_container {
+    margin-top: 5em;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+}
+
+.mission_img_placeholder{
+    margin-left: 15px;
+    background: #d3d3d3;
+    border-radius: 8px;
+    padding: 10px;
+    width: 350px;
+    height: 200px;
 }
 
 /* for mobile */
@@ -172,5 +209,18 @@ a:active { text-decoration: none; }
         width: 225px;
         height: 152px;
         margin-top: -28%;
+    }
+
+    .mission_img_container {
+        flex-direction: column;
+        margin-top: -10px;
+    }
+
+    .mission_img_placeholder {
+        margin-left: auto;
+        margin-right: auto;
+        margin-bottom: 20px;
+        width: 250px;
+        height: 150px;
     }
 }

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -8,40 +8,32 @@ const Home: React.FC<HomeProps> = (props) => {
   return (
     <div className="Home">
       <div className="landing_page_top_section">
-
         <div className="t_row">
             <div className="landing_page_title">
               <p>{TEXT.LANDING_PAGE.TITLE}</p>
             </div>
           </div>
-
           <div className="t_row">
             <div className="img_placeholder"></div>
-
           <div className="t_row">
               <div className="landing_page_description">
                 <p>{TEXT.LANDING_PAGE.DESCRIPTION}</p>
               </div>
           </div>
-
           <div className="btn_ubc_home">
             <a href="https://www.ubc.ca" style={{display: "flex", justifyContent: "center", alignItems: "center", color: "#ffffff"}}>
               <p>{TEXT.LANDING_PAGE.UBC_PAGE_BUTTON}</p>
             </a>
           </div>
-
         </div>
-
         <div className="mission_statement_title">
           <p>{TEXT.MISSION_STATEMENT.TITLE}</p>
           <hr className="horizontal_divider"/>
         </div>
-
         <div>
           <p className="mission_statement">{TEXT.MISSION_STATEMENT.LAB_GOALS}</p>
           <p className="mission_statement">{TEXT.MISSION_STATEMENT.LAB_GOALS}</p>
         </div>
-
         <div className="mission_img_container">
           <div className="mission_img_placeholder"></div>
           <div className="mission_img_placeholder"></div>

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -8,23 +8,43 @@ const Home: React.FC<HomeProps> = (props) => {
   return (
     <div className="Home">
       <div className="landing_page_top_section">
+
         <div className="t_row">
             <div className="landing_page_title">
               <p>{TEXT.LANDING_PAGE.TITLE}</p>
             </div>
           </div>
+
           <div className="t_row">
             <div className="img_placeholder"></div>
+
           <div className="t_row">
               <div className="landing_page_description">
                 <p>{TEXT.LANDING_PAGE.DESCRIPTION}</p>
               </div>
           </div>
+
           <div className="btn_ubc_home">
             <a href="https://www.ubc.ca" style={{display: "flex", justifyContent: "center", alignItems: "center", color: "#ffffff"}}>
               <p>{TEXT.LANDING_PAGE.UBC_PAGE_BUTTON}</p>
             </a>
           </div>
+
+        </div>
+
+        <div className="mission_statement_title">
+          <p>{TEXT.MISSION_STATEMENT.TITLE}</p>
+          <hr className="horizontal_divider"/>
+        </div>
+
+        <div>
+          <p className="mission_statement">{TEXT.MISSION_STATEMENT.LAB_GOALS}</p>
+          <p className="mission_statement">{TEXT.MISSION_STATEMENT.LAB_GOALS}</p>
+        </div>
+
+        <div className="mission_img_container">
+          <div className="mission_img_placeholder"></div>
+          <div className="mission_img_placeholder"></div>
         </div>
       </div>
     </div>

--- a/src/statics/text.ts
+++ b/src/statics/text.ts
@@ -58,7 +58,12 @@ const TEXT = {
       TITLE: 'Investigating Visual Intelligence',
       DESCRIPTION: 'What is the Visual Cognition Lab? We investigate visual intelligence – '+ 
                   'the way in which the human visual system uses the light entering the eyes to create a variety of perceptual experiences.',
-      UBC_PAGE_BUTTON: 'Official UBC Home Page'      
+      UBC_PAGE_BUTTON: 'Official UBC Home Page'
+  },
+
+  MISSION_STATEMENT: {
+    TITLE: 'Mission Statement',
+    LAB_GOALS: 'Description of the goals of the lab here. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
   }
 } as const;
 


### PR DESCRIPTION
### Trello Ticket
This PR closes the following Trello ticket: https://trello.com/c/lmu6XXyl/59-implement-mission-statement-and-a-couple-photos

### Description
Implement the Mission Statement section of the Landing page such that it looks like this on wider screens:

<img width="500" alt="mission statement large screen" src="https://user-images.githubusercontent.com/71746168/171071435-da9d2c20-15f5-4115-a7f2-ad189aadfa38.png">


And like this on the smaller screens (e.g.: personal smart phones): 

<img width="200" alt="mission statement mobile" src="https://user-images.githubusercontent.com/71746168/171071284-a7c364b8-aa36-400d-bb4e-1978fc0daff2.png">

### Tests
The code was tested by running the VCL content platform app on a local host and testing the front-end changes there on mobile and laptop screens through the inspect option.
