### PR TITLE
Implement the Project Overview page (front-end)

### DIFF
--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -88,7 +88,7 @@ const Navbar: React.FC<{}> = () => {
                     }}
                 >
                     <MenuItem onClick={handleProjectMenuClose}>
-                                <GenericLink name="Overview" to={`${ROUTES.PROJECT.BASE}`}/>
+                                <GenericLink name="All Projects" to={`${ROUTES.PROJECT.BASE}`}/>
                     </MenuItem>
                     {
                         projects.map((e, i) => {

--- a/src/pages/Project/ProjectOverview.css
+++ b/src/pages/Project/ProjectOverview.css
@@ -1,0 +1,43 @@
+.project-overview-container {
+    padding-top: 70px;
+    padding-bottom: 70px;
+    padding-left: 130px;
+    padding-right: 130px;
+    text-align: left;
+}
+
+.project-overview-title {
+    color: #1C426D;
+    letter-spacing: 1px;
+}
+
+hr {
+    border-top: 2px solid #8EA9D2;
+    width: 80%;
+    margin-left: 0px;
+    margin-top: -7px;
+}
+
+.button-container {
+    margin-top: 2em;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+}
+
+.project-button {
+    background-color: #AEC7E3;
+    width: 12em;
+    height: 8em;
+    margin-right: 1em;
+    margin-bottom: 1em;
+    border: none;
+    color: white;
+    font-size: 25px;
+    font-weight: bold;
+    text-align: center;
+}
+
+.project-button:hover {
+    background-color: #1C426D;;
+}

--- a/src/pages/Project/ProjectOverview.css
+++ b/src/pages/Project/ProjectOverview.css
@@ -1,8 +1,8 @@
 .project-overview-container {
     padding-top: 70px;
     padding-bottom: 70px;
-    padding-left: 130px;
-    padding-right: 130px;
+    padding-left: 90px;
+    padding-right: 90px;
     text-align: left;
 }
 
@@ -13,7 +13,7 @@
 
 hr {
     border-top: 2px solid #8EA9D2;
-    width: 80%;
+    width: 75%;
     margin-left: 0px;
     margin-top: -7px;
 }
@@ -28,7 +28,7 @@ hr {
 .project-button {
     background-color: #AEC7E3;
     width: 12em;
-    height: 8em;
+    height: 7.5em;
     margin-right: 1em;
     margin-bottom: 1em;
     border: none;

--- a/src/pages/Project/ProjectOverview.tsx
+++ b/src/pages/Project/ProjectOverview.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { useAppSelector } from '@redux/hooks';
 import { selectProjects } from '@redux/slices/ProjectRedux';
 import GenericLink from '@components/generics/Link'
-import { ROUTES } from '@statics';
+import { ROUTES, TEXT } from '@statics';
 import "./ProjectOverview.css";
 
 const ProjectOverview = () => {
@@ -14,12 +14,13 @@ const ProjectOverview = () => {
                 <h2 className='project-overview-title'>All Projects</h2>
                 <hr/>
             </div>
+            {/* TODO: refactor to fetch data from backend, currently hard-coded */}
             <div className='button-container'>
-                <button className="project-button">Correlation</button>
-                <button className="project-button">IDEO</button>
-                <button className="project-button">Image Transitions</button>
-                <button className="project-button">NOVA</button>
-                <button className="project-button">Perceptual Modes</button>
+                <button className="project-button">{TEXT.PROJECT_NAMES.CORRELATION}</button>
+                <button className="project-button">{TEXT.PROJECT_NAMES.IDEO}</button>
+                <button className="project-button">{TEXT.PROJECT_NAMES.IMG_TRANSITIONS}</button>
+                <button className="project-button">{TEXT.PROJECT_NAMES.NOVA}</button>
+                <button className="project-button">{TEXT.PROJECT_NAMES.PERCEPTUAL_MODES}</button>
             <div>
                 {projects.map((project, i) => {
                     return (

--- a/src/pages/Project/ProjectOverview.tsx
+++ b/src/pages/Project/ProjectOverview.tsx
@@ -3,15 +3,23 @@ import { useAppSelector } from '@redux/hooks';
 import { selectProjects } from '@redux/slices/ProjectRedux';
 import GenericLink from '@components/generics/Link'
 import { ROUTES } from '@statics';
+import "./ProjectOverview.css";
 
 const ProjectOverview = () => {
     const projects = useAppSelector(selectProjects); 
 
     return (
-        <div>
+        <div className='project-overview-container'>
             <div>
-                All Projects
+                <h2 className='project-overview-title'>All Projects</h2>
+                <hr/>
             </div>
+            <div className='button-container'>
+                <button className="project-button">Correlation</button>
+                <button className="project-button">IDEO</button>
+                <button className="project-button">Image Transitions</button>
+                <button className="project-button">NOVA</button>
+                <button className="project-button">Perceptual Modes</button>
             <div>
                 {projects.map((project, i) => {
                     return (
@@ -21,6 +29,7 @@ const ProjectOverview = () => {
                         </li>
                     )
                 })}
+            </div>
             </div>
         </div>
            )

--- a/src/statics/text.ts
+++ b/src/statics/text.ts
@@ -39,6 +39,14 @@ const TEXT = {
       CONTACT: 'Contact',
   },
 
+  PROJECT_NAMES: {
+    CORRELATION: 'Correlation',
+    IDEO: 'IDEO',
+    IMG_TRANSITIONS: 'Image Transitions',
+    NOVA: 'NOVA',
+    PERCEPTUAL_MODES: 'Perceptual Modes',
+},
+
   ALERTS: {
     AUTH_SUCCESS: 'Authentication successful.',
     AUTH_FAILED: 'Authentication failed.',


### PR DESCRIPTION
### Trello Ticket

This PR closes the following Trello ticket: https://trello.com/c/LbYFVeMS/66-implement-projects-overview

### Description

Implement the Project Overview page such that it looks like this on wider screens (e.g., personal laptops):

<img width="1300" alt="Screen Shot 2022-06-19 at 1 30 37 PM" src="https://user-images.githubusercontent.com/71746168/174499452-039e633e-94c5-4c50-ba85-0aaa54a33838.png">

And looks like this when a button is hovered over:

<img width="500" alt="Screen Shot 2022-06-19 at 1 59 32 PM" src="https://user-images.githubusercontent.com/71746168/174500197-8a57f217-5f03-4ceb-bbed-aa48a3711178.png">


The Project Overview page looks like this on smaller screens (e.g., personal phone):

<img width="200" alt="Screen Shot 2022-06-19 at 1 30 59 PM" src="https://user-images.githubusercontent.com/71746168/174499487-1a4f7c2a-80a9-4efe-b988-38640f1e849f.png">

This PR currently implements the Project Overview page using hard-coded values of projects. A follow-up PR will be created to instead fetch project names from the backend. 