### PR TITLE
Sarah/ Add Mission Statement Footer

### DIFF
--- a/src/pages/Home/Home.css
+++ b/src/pages/Home/Home.css
@@ -26,9 +26,9 @@
     overflow: scroll;
 }
 
-.horizontal-divider {
+.title-underline {
     max-width: 100%; 
-    width: 7.5em;
+    width: 7em;
     border-bottom: 1px solid #77B0F3; 
     line-height: 0.1em;
     margin: -15px 20em 1.25em; 
@@ -45,13 +45,30 @@
     justify-content: center;
 }
 
-.mission-img-placeholder{
+.mission-img-placeholder {
     margin-left: 15px;
     background: #d3d3d3;
     border-radius: 8px;
     padding: 10px;
     width: 350px;
     height: 200px;
+}
+
+.footer-divider {
+    width: 225px;
+    border-bottom: 2px solid #7C9DAF; 
+    margin-left: 40%;
+    margin-bottom: 3rem;
+    margin-top: -10px;
+}
+
+.mission-statement-footer {
+    margin-top: 5%;
+    padding: 70px 190px 50px;
+    background-color: #D9E3E7;
+    text-align: relative;
+    font-size: 14px;
+    letter-spacing: 0.035em;
 }
 
 @media (max-width:1025px){
@@ -77,5 +94,16 @@
         margin-bottom: 20px;
         width: 300px;
         height: 200px;
+    }
+
+    .footer-divider {
+        margin-left: 25%;
+    }
+
+    .mission-statement-footer {
+        padding-left: 25%;
+        padding-right: 25%;
+        margin-left: 25%;
+        margin-bottom: 5%;
     }
 }

--- a/src/pages/Home/Home.css
+++ b/src/pages/Home/Home.css
@@ -97,12 +97,13 @@
     }
 
     .footer-divider {
-        margin-left: 25%;
+        width: 200px;
+        margin-left: 15%;
     }
 
     .mission-statement-footer {
-        padding-left: 25%;
-        padding-right: 25%;
+        padding-left: 28%;
+        padding-right: 28%;
         margin-left: 25%;
         margin-bottom: 5%;
     }

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -18,7 +18,7 @@ const Home: React.FC<HomeProps> = (props) => {
       <div className="mission-statement-container">
         <div className="mission-statement-title">
             <p>{TEXT.LANDING_PAGE.MISSION_STATEMENT.TITLE}</p>
-            <hr className="horizontal-divider"/>
+            <hr className="title-underline"/>
         </div>
         <div>
           <p className="mission-statement">{TEXT.LANDING_PAGE.MISSION_STATEMENT.LAB_GOALS}</p>
@@ -28,6 +28,10 @@ const Home: React.FC<HomeProps> = (props) => {
       <div className="mission-img-container">
         <div className="mission-img-placeholder"></div>
         <div className="mission-img-placeholder"></div>
+      </div>
+      <div className="mission-statement-footer">
+        <hr className="footer-divider"/>
+        <p>{TEXT.LANDING_PAGE.MISSION_STATEMENT.LAB_GOALS}</p>
       </div>
     </div>
   );


### PR DESCRIPTION
### Dev Note

This PR adds a mission statement footer beneath the previously implemented mission statement paragraph and pictures.

### Trello Ticket

This PR is a followup to the following Trello ticket: https://trello.com/c/lmu6XXyl/59-implement-mission-statement-and-a-couple-photos

### Description
Implement the Mission Statement footer section of the Landing page such that it looks like this on wider screens:

<img width="1414" alt="Screen Shot 2022-08-12 at 3 34 05 PM" src="https://user-images.githubusercontent.com/71746168/184453479-5255367b-0cd1-4998-afee-3fa4972249f9.png">

And like this on the smaller screens (e.g.: personal smart phones): 

<img width="300" alt="Screen Shot 2022-08-12 at 3 38 23 PM" src="https://user-images.githubusercontent.com/71746168/184453500-f6cb14c9-9e86-4e8a-a64e-c4b8d015922c.png">


### Tests
The code was tested by running the VCL content platform app on a local host and testing the front-end changes there on mobile and laptop screens through the inspect option.
