### PR TITLE
Make Mission Statement Footer A Reusable Component

### DIFF
--- a/src/components/MissionStatement/MissionStatement.css
+++ b/src/components/MissionStatement/MissionStatement.css
@@ -1,0 +1,30 @@
+.footer-divider {
+    width: 225px;
+    border-bottom: 2px solid #7C9DAF; 
+    margin-left: 40%;
+    margin-bottom: 3rem;
+    margin-top: -10px;
+}
+
+.mission-statement-footer {
+    margin-top: 100px;
+    padding: 70px 190px 50px;
+    background-color: #D9E3E7;
+    text-align: relative;
+    font-size: 14px;
+    letter-spacing: 0.035em;
+}
+
+@media (max-width:1025px) {
+    .footer-divider {
+        width: 200px;
+        margin-left: 15%;
+    }
+
+    .mission-statement-footer {
+        padding-left: 28%;
+        padding-right: 28%;
+        margin-left: 25%;
+        margin-bottom: 5%;
+    }
+}

--- a/src/components/MissionStatement/MissionStatement.tsx
+++ b/src/components/MissionStatement/MissionStatement.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { TEXT } from '@statics';
+import './MissionStatement.css'
+
+const MissionStatement = () => {
+    return (
+
+      <div className="mission-statement-footer">
+        <hr className="footer-divider"/>
+        <p>{TEXT.LANDING_PAGE.MISSION_STATEMENT.LAB_GOALS}</p>
+      </div>
+
+    )
+}
+
+export default MissionStatement;

--- a/src/components/MissionStatement/index.ts
+++ b/src/components/MissionStatement/index.ts
@@ -1,0 +1,1 @@
+export { default } from './MissionStatement';

--- a/src/pages/About/About.tsx
+++ b/src/pages/About/About.tsx
@@ -5,6 +5,7 @@ import { TEXT } from '@statics';
 import kennyMap from '@statics/images/kenny-map.png';
 import Card from '@components/Card';
 import Footer from '@components/Footer';
+import MissionStatement from '@components/MissionStatement';
 
 interface AboutProps {}
 
@@ -102,6 +103,7 @@ const About: React.FC<AboutProps> = props => {
 						</Grid>
 				</Grid>
 			</div>
+			<MissionStatement />
 		</div>
 	);
 };

--- a/src/pages/Home/Home.css
+++ b/src/pages/Home/Home.css
@@ -64,23 +64,6 @@
     height: 263px;
 }
 
-.footer-divider {
-    width: 225px;
-    border-bottom: 2px solid #7C9DAF; 
-    margin-left: 40%;
-    margin-bottom: 3rem;
-    margin-top: -10px;
-}
-
-.mission-statement-footer {
-    margin-top: 100px;
-    padding: 70px 190px 50px;
-    background-color: #D9E3E7;
-    text-align: relative;
-    font-size: 14px;
-    letter-spacing: 0.035em;
-}
-
 @media (max-width:1025px){
     .card-container {
         overflow-y: hidden !important;
@@ -114,17 +97,5 @@
         margin-bottom: 20px;
         width: 300px;
         height: 200px;
-    }
-
-    .footer-divider {
-        width: 200px;
-        margin-left: 15%;
-    }
-
-    .mission-statement-footer {
-        padding-left: 28%;
-        padding-right: 28%;
-        margin-left: 25%;
-        margin-bottom: 5%;
     }
 }

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Card from "@components/Card";
 import "./Home.css"
 import { TEXT } from '@statics';
+import MissionStatement from "@components/MissionStatement";
 
 interface HomeProps {}
 
@@ -29,10 +30,7 @@ const Home: React.FC<HomeProps> = (props) => {
         <div className="mission-img-placeholder-one"></div>
         <div className="mission-img-placeholder-two"></div>
       </div>
-      <div className="mission-statement-footer">
-        <hr className="footer-divider"/>
-        <p>{TEXT.LANDING_PAGE.MISSION_STATEMENT.LAB_GOALS}</p>
-      </div>
+      <MissionStatement />
     </div>
   );
 };


### PR DESCRIPTION
## What Does This PR Do?

This PR makes the mission statement footer a reusable component such that it can be used in both the Home and About pages as seen in Figma: 

### Home Page:

<img width="1429" alt="Home page with mission statement footer" src="https://user-images.githubusercontent.com/71746168/194202388-f4f8956f-8768-46a0-bb21-dd3ec15d44f3.png">


### About Page :
<img width="1427" alt="About page with mission statement footer" src="https://user-images.githubusercontent.com/71746168/194202135-358cc8bb-6c06-4c59-8572-31970c50b522.png">
