### PR TITLE
Completed the "Project sidebar change" ticket

### DIFF
--- a/src/components/ProjectNavbar/ProjectNavbar.tsx
+++ b/src/components/ProjectNavbar/ProjectNavbar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {makeStyles, styled, useTheme} from '@mui/material/styles';
+import {styled, useTheme} from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Drawer from '@mui/material/Drawer';
 import CssBaseline from '@mui/material/CssBaseline';
@@ -16,7 +16,7 @@ import {Link} from "react-router-dom";
 import {Route, Switch} from "react-router";
 import {ProjectDefault, ProjectJoin, ProjectResources, ProjectTeam} from "@pages/Project";
 import FirstPageTwoToneIcon from '@mui/icons-material/FirstPageTwoTone';
-import {AppBar, Button, useMediaQuery} from "@mui/material";
+import {Button} from "@mui/material";
 import {ROUTES} from "@statics";
 import Nova from '@pages/Project/Nova/nova';
 import Correlation from '@pages/Project/Correlation/correlation';

--- a/src/components/ProjectNavbar/ProjectNavbar.tsx
+++ b/src/components/ProjectNavbar/ProjectNavbar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {styled, useTheme} from '@mui/material/styles';
+import {makeStyles, styled, useTheme} from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Drawer from '@mui/material/Drawer';
 import CssBaseline from '@mui/material/CssBaseline';
@@ -16,7 +16,7 @@ import {Link} from "react-router-dom";
 import {Route, Switch} from "react-router";
 import {ProjectDefault, ProjectJoin, ProjectResources, ProjectTeam} from "@pages/Project";
 import FirstPageTwoToneIcon from '@mui/icons-material/FirstPageTwoTone';
-import {Button} from "@mui/material";
+import {AppBar, Button, useMediaQuery} from "@mui/material";
 import {ROUTES} from "@statics";
 import Nova from '@pages/Project/Nova/nova';
 import Correlation from '@pages/Project/Correlation/correlation';
@@ -48,7 +48,7 @@ const Main = styled('main', { shouldForwardProp: (prop) => prop !== 'open' })<{
 const DrawerHeader = styled('div')(({theme}) => ({
     display: 'flex',
     alignItems: 'center',
-    padding: theme.spacing(0, 1),
+    padding: theme.spacing(0, 0),
     // necessary for content to be below app bar
     ...theme.mixins.toolbar,
     justifyContent: 'flex-end',
@@ -56,9 +56,8 @@ const DrawerHeader = styled('div')(({theme}) => ({
 
 export default function Sidebar(props: any) {
 
-
     const theme = useTheme();
-    const [open, setOpen] = React.useState(false);
+    const [open, setOpen] = React.useState(true);
 
     const handleDrawerOpen = () => {
         setOpen(true);
@@ -88,8 +87,10 @@ export default function Sidebar(props: any) {
                     width: drawerWidth,
                     flexShrink: 0,
                     '& .MuiDrawer-paper': {
+                        position: 'sticky',
                         width: drawerWidth,
                         boxSizing: 'border-box',
+                        borderColor: 'white'  
                     },
                 }}
                 variant="persistent"
@@ -102,27 +103,27 @@ export default function Sidebar(props: any) {
                     </IconButton>
                 </DrawerHeader>
                 <List>
-                    <Typography variant='subtitle2' marginLeft='30px' color = '#AEC7E3'>
+                    <Typography variant='subtitle2' marginLeft='10px' color = '#AEC7E3'>
                         Now Viewing
                     </Typography>
                     <ListItem>
-                        <Typography variant='h5' padding='15px' color = '#1C426D' fontWeight='bold'>
+                        <Typography variant='h5' marginTop='15px' marginLeft='-6px' marginBottom='10px' color = '#1C426D' fontWeight='bold'>
                             {props.currProject.name}
                         </Typography>
                     </ListItem>
-                    <Divider variant ='middle' sx={{ borderBottomWidth: 2 }} color='#B2C9EC'/>
+                    <Divider sx={{ borderBottomWidth: 1, marginBottom:'35px'}} color='#B2C9EC'/>
 
                     {props.links.map((link: any, index: any) => (
                         <ListItem key={link.title}>
                             <ListItemButton component={Link} to={link.ref}>
-                                <Typography color = '#5B7E98'>
+                                <Typography color = '#5B7E98' marginLeft='-25px'>
                                     {link.title}
                                 </Typography>
                             </ListItemButton>
                         </ListItem>
 
                     ))}
-                    <Box textAlign='center' padding='50px'>
+                    <Box textAlign='left' marginTop='50px'>
                         <Button onClick={() => {
                             window.location.pathname=ROUTES.PROJECT.BASE
                         }} variant ='outlined' style={{textTransform: 'none'}}>


### PR DESCRIPTION
## Description

[Please enter a brief description of the PR]

Originally the project sidebar was positioned above the nav bar and the footer. 

**To Note: there are two commits attached to this PR, as the first commit sought to address the underlying issue, then the second commit was to remove unneeded imports. 

Changes made to address this issue:
1. altered the padding of the drawer header to pull the close button closer to the border (line 51)
2. changed the default state of the drawer to be opened (line 60)
3. Changed the MuiDrawer-paper's position to be sticky to prevent the sidebar from being positioned above the nav bar and  the footer (line 90)
4. changed the border colour to be white to more closely match the Figma mock-up (line 93)
5. Altered the margins of the list items within the sidebar to more closely resemble the Figma mockup (line 106, 110, 114, 119, 126)

## Updates

[Please enter a brief summary of updates to this PR during code review - if any]

## Checklist

- [ DONE] Ran `npm run lint:fix` to format code
- [ DONE] Requested at least one reviewer
- [ DONE] Connected PR to Trello ticket (steps below)
- [TO-DO ] Addressed code review comments
- [ TO-DO] Gained at least one approval for your PR

## Connecting your PR to the corresponding ticket:
- Click on the "GitHub" button found on the right of your Trello ticket
- Choose "Attach PR" from the dropdown list
- Link your GitHub account (if you haven't done so already)
- Navigate to`VCL-content-platform` and choose your PR from the dropdown. 