### PR TITLE
Replace MissionStatement with LabGoalsFooter in Get Involved page.

### DIFF
--- a/src/pages/JoinTheTeam/JoinTheTeam.tsx
+++ b/src/pages/JoinTheTeam/JoinTheTeam.tsx
@@ -5,7 +5,7 @@ import { TEXT } from '@statics';
 import kennyMap from '@statics/images/kenny-map.png';
 import Card from '@components/Card';
 import Footer from '@components/Footer';
-import MissionStatement from '@components/MissionStatement';
+import LabGoalsFooter from '@components/LabGoalsFooter';
 import Divider from '@mui/material/Divider';
 import { Link } from 'react-router-dom';
 
@@ -294,7 +294,7 @@ const JoinTheTeam: React.FC<JoinTheTeamProps> = props => {
 					</p>
 				</section>
 			</div>
-			<MissionStatement />
+			<LabGoalsFooter />
 		</div>
 	);
 };


### PR DESCRIPTION
## Description

Fixes the following compiler issue caused by component rename from `MissionStatement` to `LabGoalsFooter`. 

<img width="1066" alt="Screen Shot 2023-02-22 at 6 41 29 PM" src="https://user-images.githubusercontent.com/71746168/220810319-bdbbb077-4e34-4ee8-8d48-6801d610b6ae.png">


## Updates

[Please enter a brief summary of updates to this PR during code review - if any]

## Checklist

- [ ] Ran `npm run lint:fix` to format code
- [ ] Requested at least one reviewer
- [ ] Connected PR to Trello ticket (steps below)
- [ ] Addressed code review comments
- [ ] Gained at least one approval for your PR

## Connecting your PR to the corresponding ticket:
- Click on the "GitHub" button found on the right of your Trello ticket
- Choose "Attach PR" from the dropdown list
- Link your GitHub account (if you haven't done so already)
- Navigate to`VCL-content-platform` and choose your PR from the dropdown. 