### PR TITLE
Adjust Navbar Bottom Shadow

### DIFF
--- a/src/components/Navbar/Navbar.css
+++ b/src/components/Navbar/Navbar.css
@@ -7,6 +7,7 @@
 	left: 0;
 	z-index: 1030;
 	height: auto;
+	box-shadow: rgba(149, 157, 165, 0.2) 0px 3px 2px;
 }
 
 .hamburger-menu {
@@ -77,21 +78,6 @@
 	font-size: 19px;
 }
 
-@media only screen and (max-width: 700px) {
-	.hamburger-menu {
-	  display: block;
-	}
-
-	.navbar-menu {
-	  display: none;
-	  height: 0% !important;
-	}
-
-	.nav {
-		height: 100px;
-	}
-}
-
 .logo-container {
 	margin: 4px;
 	display: flex;
@@ -152,29 +138,6 @@
 	}
 }
 
-@media only screen and (max-width: 880px) {
-	.logo-container p {
-		font-size: 12px;
-		width: 120px;
-		text-align: center;
-	}
-
-	.nav-rendered-links > * {
-		font-size: 14px;
-	}
-}
-
-@media (min-width: 700px) {
-	.css-hyum1k-MuiToolbar-root {
-		padding-top: 4px !important;
-		padding-bottom: 4px !important;
-	}
-}
-
-.nav-appbar {
-	margin-bottom: 10px;
-}
-
 .nav-toolbar {
 	box-sizing: border-box;
 	display: flex;
@@ -214,3 +177,38 @@
 .vcl-title-link:hover {
 	text-decoration: none;
 }
+@media only screen and (max-width: 700px) {
+	.hamburger-menu {
+	  display: block;
+	}
+
+	.navbar-menu {
+	  display: none;
+	  height: 0% !important;
+	}
+
+	.nav {
+		height: 100px;
+	}
+}
+
+@media only screen and (max-width: 880px) {
+	.logo-container p {
+		font-size: 12px;
+		width: 120px;
+		text-align: center;
+	}
+
+	.nav-rendered-links > * {
+		font-size: 14px;
+	}
+}
+
+@media (min-width: 700px) {
+	.css-hyum1k-MuiToolbar-root {
+		padding-top: 4px !important;
+		padding-bottom: 4px !important;
+	}
+}
+
+

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -137,7 +137,6 @@ const Navbar: React.FC<{}> = () => {
   return (
     <div className="nav">
       <div className="navbar-menu">
-        <AppBar position="sticky" className="nav-appbar">
         <Toolbar className="nav-toolbar">
           <div className="logo-container">
             <a href={ROUTES.HOME}>
@@ -173,7 +172,6 @@ const Navbar: React.FC<{}> = () => {
             )}
           </Menu>
         </Toolbar>
-      </AppBar>
       </div>
         <MobileMenu/>
     </div>


### PR DESCRIPTION
## Description

This PR adjusts the main navbar as follows:

#### Previously:

<img width="1440" alt="Screen Shot 2023-06-30 at 9 59 22 PM" src="https://github.com/UBC-VCL/VCL-content-platform/assets/71746168/a51c856c-9f9d-473c-a2de-7667cee87804">

#### Now:

<img width="1434" alt="Screen Shot 2023-06-30 at 10 00 30 PM" src="https://github.com/UBC-VCL/VCL-content-platform/assets/71746168/2d6e3061-88e6-48fa-88a5-3d54148c4db4">

Additionally, all screen-width related css styling is moved to the bottom of the Navbar.css page for consistency with other existing css files in codebase.

## Updates

[Please enter a brief summary of updates to this PR during code review - if any]

## Checklist

- [ ] Ran `npm run lint:fix` to format code
- [ ] Requested at least one reviewer
- [ ] Connected PR to Trello ticket (steps below)
- [ ] Addressed code review comments
- [ ] Gained at least one approval for your PR

## Connecting your PR to the corresponding ticket:
- Click on the "GitHub" button found on the right of your Trello ticket
- Choose "Attach PR" from the dropdown list
- Link your GitHub account (if you haven't done so already)
- Navigate to`VCL-content-platform` and choose your PR from the dropdown. 