### PR TITLE
Make VCL logo and Title More Responsive to Resizing

### DIFF
--- a/src/components/MobileNavbar/MobileNavbar.css
+++ b/src/components/MobileNavbar/MobileNavbar.css
@@ -13,6 +13,10 @@
     background-color: #F8F8F8 !important;
 }
 
+.mobile-vcl-logo {
+  width: 45px;
+}
+
 .title {
     font-family: 'Poppins';
     font-style: normal;

--- a/src/components/MobileNavbar/MobileNavbar.tsx
+++ b/src/components/MobileNavbar/MobileNavbar.tsx
@@ -13,7 +13,7 @@ import { selectIsLoggedIn } from '@redux/slices/AuthRedux';
 import AccountCircleIcon from '@mui/icons-material/AccountCircle';
 import './MobileNavbar.css';
 import {ReactComponent as SearchIcon} from '@statics/images/search-icon.svg';
-import {ReactComponent as VCLIcon} from '@statics/images/vcl-icon2.svg';
+import VCLIcon from '@statics/images/new-vcl-icon.png';
 import { slide as MobileMenu } from 'react-burger-menu';
 
 const MobileNavbar = () => {
@@ -56,7 +56,7 @@ const MobileNavbar = () => {
         <div className="container">
         <AppBar position="fixed" className="mobile-header">
             <div>
-              <VCLIcon/>
+            <img src={VCLIcon} alt="VCL logo" className="mobile-vcl-logo"/>
             <div className="title">{TEXT.COMMON.TITLE}</div>
             </div>
             <div className="row">

--- a/src/components/Navbar/Navbar.css
+++ b/src/components/Navbar/Navbar.css
@@ -202,6 +202,15 @@
 	.nav-rendered-links > * {
 		font-size: 14px;
 	}
+
+	.vcl-logo {
+		margin-right: 7em;
+	}
+	
+	.vcl-title-link {
+		font-size: 14px;
+		margin-top: -5em;
+	}
 }
 
 @media (min-width: 700px) {


### PR DESCRIPTION
## Description

- Change VCL logo in mobile view
- Adjust VCL logo and icon in the main navbar to be more responsive to screens of different sizes. 

#### Mobile:

<img width="200" alt="Screen Shot 2023-07-04 at 3 41 27 PM" src="https://github.com/UBC-VCL/VCL-content-platform/assets/71746168/978358ac-c1f6-4286-ad92-2abe6505b4c1">

#### Smallest width before switching to mobile view: 

<img width="400" alt="Screen Shot 2023-07-04 at 3 43 57 PM" src="https://github.com/UBC-VCL/VCL-content-platform/assets/71746168/43e02af1-7a1f-4e21-a8e5-9d8d6bc75675">



## Updates

[Please enter a brief summary of updates to this PR during code review - if any]

## Checklist

- [ ] Ran `npm run lint:fix` to format code
- [ ] Requested at least one reviewer
- [ ] Connected PR to Trello ticket (steps below)
- [ ] Addressed code review comments
- [ ] Gained at least one approval for your PR

## Connecting your PR to the corresponding ticket:
- Click on the "GitHub" button found on the right of your Trello ticket
- Choose "Attach PR" from the dropdown list
- Link your GitHub account (if you haven't done so already)
- Navigate to`VCL-content-platform` and choose your PR from the dropdown. 