### PR TITLE
Fix Project Default UI Bug

### DIFF
--- a/src/components/GetInvolvedSidebar/GetInvolvedSidebar.css
+++ b/src/components/GetInvolvedSidebar/GetInvolvedSidebar.css
@@ -156,13 +156,13 @@ ul {
     animation-name: slide-in;
     display:block;
     animation-timing-function: linear;
-    animation-duration: 0.5s;
+    animation-duration: 0.4s;
 }
 
 .animationOff {
     animation-name: slide-out;
     animation-timing-function: linear;
-    animation-duration: 0.5s;
+    animation-duration: 0.4s;
 }
 
 @keyframes slide-in {

--- a/src/components/ProjectDescription/ProjectDescription.css
+++ b/src/components/ProjectDescription/ProjectDescription.css
@@ -14,7 +14,7 @@
 
 .project-description-paragraph-one,
 .project-description-paragraph-two {
-    color: #92AED8;
+    color: white;
     font-size: 16px;
     line-height: 29px;
     letter-spacing: 0.08px;

--- a/src/components/ProjectNavbar/ProjectNavbar.css
+++ b/src/components/ProjectNavbar/ProjectNavbar.css
@@ -8,6 +8,7 @@
     height: 70px;
     width: 70px;
     border-radius: 1px;
+    z-index: 1 !important;
 }
 
 

--- a/src/components/ProjectNavbar/ProjectNavbar.tsx
+++ b/src/components/ProjectNavbar/ProjectNavbar.tsx
@@ -77,7 +77,7 @@ export default function Sidebar(props: any) {
                     edge="start"
                     sx={{...(open && {display: 'none'})}}
                 >
-                    <MenuIcon sx={{width: "58px", height: "38px", color: "white", zIndex: '5'}}/>
+                    <MenuIcon sx={{width: "58px", height: "38px", color: "white"}}/>
                 </IconButton>
             </div>
 
@@ -98,7 +98,7 @@ export default function Sidebar(props: any) {
             >
                 <div className='DrawerHeader'>
                 <DrawerHeader>
-                    <IconButton onClick={handleDrawerClose} style={{marginTop:"25%"}}>
+                    <IconButton onClick={handleDrawerClose} style={{marginTop:"25%", zIndex: "2"}}>
                         {theme.direction === 'ltr' ? <FirstPageTwoToneIcon/> : <ChevronRightIcon/>}
                     </IconButton>
                 </DrawerHeader>

--- a/src/pages/Project/ProjectDefault.css
+++ b/src/pages/Project/ProjectDefault.css
@@ -34,18 +34,27 @@ h1, h2, h3, p {
     text-align: left;
 }
 
+.top-cog-container {
+    position: absolute;
+    margin-left: -260px;
+    margin-top: -120px;
+}
+
 .top-left-cog {
     height: 226px;
-    margin-top: -12%;
-    margin-left: -27.25%;
+    flex-shrink:0;
+}
+
+.bottom-cog-container {
+    position: absolute;
+    left: 77em;
+    top: 300px; 
 }
 
 .bottom-right-cog {
-    position: absolute;
     width: 400px;
     height: 400px;
-    left: 77em;
-    top: 300px; 
+    flex-shrink: 0;
 }
 
 .gallery-cog {

--- a/src/pages/Project/ProjectDefault.tsx
+++ b/src/pages/Project/ProjectDefault.tsx
@@ -55,8 +55,12 @@ const ProjectDefault: React.FC<ProjectProps> = (props) => {
         <div className='main'>
             <div className='description-container'>
 
-                <img src={TopLeftCog} className="top-left-cog" alt="a design elemnt depicting a set of cogs" />
-                <img src={BottomRightCog} className="bottom-right-cog" alt="a design elemnt depicting a set of cogs" />
+                <div className="top-cog-container">
+                    <img src={TopLeftCog} className="top-left-cog" alt="a design elemnt depicting a set of cogs" />
+                </div>
+                <div className='bottom-cog-container'>
+                    <img src={BottomRightCog} className="bottom-right-cog" alt="a design elemnt depicting a set of cogs" />
+                </div>
 
                  <ProjectBreadcrumbs project_name={props.project.name} page_name={TEXT.PROJECT_NAV.PROJECT_DESCRIPTION}/> 
 


### PR DESCRIPTION
## Description

This PR:
- Changes project description color to white as per feedback requests
- Makes Get Involved sidebar transitions a little quicker
- Fixes the following issue with the project default UI design:

<img alt="picture of UI bug" width="300" src="https://github.com/UBC-VCL/VCL-content-platform/assets/71746168/c9e04fe9-2f09-4b4a-8bec-5c6ae13ed731">

Now the UI design should look like the following on bigger screens:

<img width="1438" alt="Screen Shot 2023-07-17 at 12 34 00 AM" src="https://github.com/UBC-VCL/VCL-content-platform/assets/71746168/45c24cff-2c29-4abe-807f-13a4af62f0dd">

## Updates

[Please enter a brief summary of updates to this PR during code review - if any]

## Checklist

- [ ] Ran `npm run lint:fix` to format code
- [ ] Requested at least one reviewer
- [ ] Connected PR to Trello ticket (steps below)
- [ ] Addressed code review comments
- [ ] Gained at least one approval for your PR

## Connecting your PR to the corresponding ticket:
- Click on the "GitHub" button found on the right of your Trello ticket
- Choose "Attach PR" from the dropdown list
- Link your GitHub account (if you haven't done so already)
- Navigate to`VCL-content-platform` and choose your PR from the dropdown. 