### PR TITLE
#176 make past projects more dynamic

### DIFF
--- a/src/entities/Project.ts
+++ b/src/entities/Project.ts
@@ -32,6 +32,10 @@ export interface Project {
     joinTeam?: {
         whatWeDo: string[]
     },
+    pastProjects?: {
+        title: string,
+        description: string
+    }[]
     publications?: Publication[],
     subpage?:Project[],
     galleryList?: SlideShowOBJ[],

--- a/src/pages/Project/ProjectJoin.tsx
+++ b/src/pages/Project/ProjectJoin.tsx
@@ -152,10 +152,12 @@ const ProjectJoin: React.FC<ProjectProps> = (props) => {
                     <p style={{ paddingTop: "3%" }}>03</p>
                     <h2>{TEXT.PROJECT_JOIN.PAST_POSITIONS_AND_PROJECTS.TITLE}</h2>
                     {props.project.pastProjects?.map(items =>
-                    <div className='project-join-card'>
-                        <h5>{items.title}</h5>
-                        <p>{items.description}</p>
-                    </div>
+                    <p style={{paddingTop: "2%",paddingBottom: "1%"}}>
+                        <p className='project-join-card'>
+                          <h5>{items.title}</h5>
+                          <p>{items.description}</p>
+                       </p>
+                    </p>
                         )}
                 </div>
             </section>

--- a/src/pages/Project/ProjectJoin.tsx
+++ b/src/pages/Project/ProjectJoin.tsx
@@ -147,25 +147,18 @@ const ProjectJoin: React.FC<ProjectProps> = (props) => {
       </section>
 
       {/* TODO: Make past projects dynamic */}
-      {/* <section className='full-bleed4'>
+       <section className='full-bleed4'>
                 <div className='past-positions-and-projects' style={{ paddingBottom: "2%", paddingTop: "3%" }}>
                     <p style={{ paddingTop: "3%" }}>03</p>
                     <h2>{TEXT.PROJECT_JOIN.PAST_POSITIONS_AND_PROJECTS.TITLE}</h2>
+                    {props.project.pastProjects?.map(items =>
                     <div className='project-join-card'>
-                        <h5>{TEXT.PROJECT_JOIN.PAST_POSITIONS_AND_PROJECTS.VCL_WEB_APP.TITLE}</h5>
-                        <p>{TEXT.PROJECT_JOIN.PAST_POSITIONS_AND_PROJECTS.VCL_WEB_APP.DESCRIPTION}</p>
+                        <h5>{items.title}</h5>
+                        <p>{items.description}</p>
                     </div>
-                    <div className='project-join-card'>
-                        <h5>{TEXT.PROJECT_JOIN.PAST_POSITIONS_AND_PROJECTS.PROJECT1.TITLE}</h5>
-                        <p>{TEXT.PROJECT_JOIN.PAST_POSITIONS_AND_PROJECTS.PROJECT1.DESCRIPTION}</p>
-                    </div>
-                    <div className='project-join-card'>
-                        <h5>{TEXT.PROJECT_JOIN.PAST_POSITIONS_AND_PROJECTS.PROJECT2.TITLE}</h5>
-                        <p>{TEXT.PROJECT_JOIN.PAST_POSITIONS_AND_PROJECTS.PROJECT2.DESCRIPTION}</p>
-                    </div>
+                        )}
                 </div>
-            </section> */}
-
+            </section>
       {/* <section className='full-bleed5' style={{marginTop:"10%"}}>
         <div className='what-our-team-member-say'>
             <p style={{paddingTop: "7%"}}>04</p>

--- a/src/pages/Project/ProjectJoin.tsx
+++ b/src/pages/Project/ProjectJoin.tsx
@@ -152,12 +152,12 @@ const ProjectJoin: React.FC<ProjectProps> = (props) => {
                     <p style={{ paddingTop: "3%" }}>03</p>
                     <h2>{TEXT.PROJECT_JOIN.PAST_POSITIONS_AND_PROJECTS.TITLE}</h2>
                     {props.project.pastProjects?.map(items =>
-                    <p style={{paddingTop: "2%",paddingBottom: "1%"}}>
                         <p className='project-join-card'>
+                            <p style={{paddingTop: "2%",paddingBottom: "3%", paddingRight: "3%", paddingLeft: "3%"}}>
                           <h5>{items.title}</h5>
                           <p>{items.description}</p>
+                            </p>
                        </p>
-                    </p>
                         )}
                 </div>
             </section>

--- a/src/pages/Project/ProjectWrapper.tsx
+++ b/src/pages/Project/ProjectWrapper.tsx
@@ -234,6 +234,16 @@ const ProjectWrapper: React.FC<ProjectProps> = ({ match }) => {
           description: 'During my time on the team, I have gained valuable insights and experience into the world of research. It has helped me a lot in my pursuit of both academic and career endeavors.',
           cardType: 'no-photo-test'
         },
+      ],
+      pastProjects: [
+        {
+          title: "VCL Web Framework\n",
+          description: "The online framework the Visual Cognition Lab uses to run their experiments was originally started by the correlation team and is meant to be a general use platform for all teams in the lab. We use a JavaScript library called jsPsych which facilitates experiment design and data collection. Currently, we continuously implement new experiments into the framework and update it with more quality of life features.",
+        },
+        {
+          title: "Past Correlation Experiments\n",
+          description: "Every term, we complete new experiment implementations and data collection. We have completed over 10 different Correlation-related experiments from the original default condition and design, to showing the scatterplots one after the other, and using different symbols, colors and display settings.",
+        },
       ]
     },
     {
@@ -361,8 +371,23 @@ const ProjectWrapper: React.FC<ProjectProps> = ({ match }) => {
       joinTeam: {
         whatWeDo: ["The NOVA team follows a weekly routine for collecting, analyzing and reporting about data. Every member of the team, from the project leader to the co-pilots, is trained expected to learn how to schedule meetings with participants through UBC’s Human Subject Pool website. Through HSP, meetings are scheduled with participants to run them through the experimental process for an hour, answering any questions or troubleshooting technical issues along the way. Once a week’s worth of data is collected, volunteers and research assistants analyze the data through Python on Microsoft Visual Studio Code. The analysis results are then reported to the principal investor and recorded in a shared document. Based on whether the analysis yields noteworthy results, the team may continue to run the current conditions or create a novel condition with a visual stimulus graphic."]
 
-      }
-      
+      },
+      pastProjects: [
+        {
+          title: "Cueing Using Colour and Isoluminescence: Differences in Blindness Rates and Cueing Effects Between Seen and Unseen Cues",
+          description:
+              'Author: Ankita Guha Patra' +
+              "Sponsoring Research Assistant Tiffany Wu\n" +
+              "Supervisor: Dr. Ronald Rensink\n"
+
+        },
+        {
+          title: "Does Consciousness Matter? Noticeable Edits on Overlearned Cues and the Effect on Blindness Rates and Cueing Effects Between Seen and Unseen Cues",
+          description: "Author: Isha Verma\n" +
+              "Spondoring Research Assistant: Ying Zeng\n" +
+              "Supervisor: Dr. Ronald Rensink\n"
+        },
+      ]
 
     },
     // {
@@ -447,6 +472,12 @@ const ProjectWrapper: React.FC<ProjectProps> = ({ match }) => {
           cardType: "no-photo-test",
         },
       ],
+      pastProjects: [
+        {
+          title: "Condition 54 No-Pretask\n",
+          description: "This condition was created to continue the experiment through an online environment but without the usual Navon pretask. Participants from both Japan and Canada partook in the investigation. Through the experiment, it was revealed that there were little differences between the average reaction times in Japanese and Canadian participants. However, participants found it more difficult to find long-line stimuli amongst short-line distractors than to locate short lines amongst long as the number of distractors increased. \n",
+        },
+      ]
     },
     {
       name: "Ideo",
@@ -542,6 +573,16 @@ const ProjectWrapper: React.FC<ProjectProps> = ({ match }) => {
           description:
             "VCL is an open door for those who wants to learn. From statistical analysis to running experiments, VCL is a great place to start a hands on experience in a lab. There is still much to be explored about our unconscious knowledge and it's a privilege to be able to study it with amazing people.",
           cardType: "no-photo-test",
+        },
+      ],
+      pastProjects: [
+        {
+          title: "Project 1: Exploring the Influence of Fine Motor Warm-Up Activities on Ideomotor Movement:",
+          description: "This research project was part of COGS 402 utilized the Swan Protocol and was conducted online during the COVID-19 pandemic. The Swan technique, developed by Bob Burns, serves as a tool to tap into unconscious knowledge by communicating with the hand, potentially eliciting unconscious movements that appear as though the hand possesses its own cognition. It's important to note that this concept is distinct from hypnosis, as hypnosis is not a component of our methodology.",
+        },
+        {
+          title: "Project 2:",
+          description: "Examining the Impact of Transliminality on Ideomotor Effects in Relation to Implicit Cognition: This research project was part of COGS 402 and utilized the Ouija method. The Hypothesis of this project was that \"Participants scoring higher on transliminality will exhibit greater accuracy during the Ouija phase compared to participants with lower scores.\" Transliminality reflects individual differences in the threshold at which unconscious processes or external stimuli enter into consciousness.",
         },
       ],
     },

--- a/src/pages/Project/ProjectWrapper.tsx
+++ b/src/pages/Project/ProjectWrapper.tsx
@@ -483,7 +483,12 @@ const ProjectWrapper: React.FC<ProjectProps> = ({ match }) => {
           title: "Condition 54 No-Pretask\n",
           description: "This condition was created to continue the experiment through an online environment but without the usual Navon pretask. Participants from both Japan and Canada partook in the investigation. Through the experiment, it was revealed that there were little differences between the average reaction times in Japanese and Canadian participants. However, participants found it more difficult to find long-line stimuli amongst short-line distractors than to locate short lines amongst long as the number of distractors increased. \n",
         },
-      ]
+      ],
+      joinTeam: {
+        whatWeDo:[
+          'In SHIVA, we examine factors that can shift a person’s perceptual modes. In other words, we are interested in factors that can affect how a person makes sense of their visual environment. We’re particularly interested in a person’s visual environment as well as their cultural background. To examine these factors, the participant’s visual environment is varied before and during visual search tasks. Afterwards, we collect and examine their cultural information (for more details, please check out our Q&A!). In our older tests, performing various pre-tasks before the main visual search task has seen various degrees of success in changing a person’s perceptual mode. More recently however, we have been examining how the transition to an online test environment may shift a person’s perceptual modes.'
+        ]
+      }
     },
     {
       name: "Ideo",

--- a/src/pages/Project/ProjectWrapper.tsx
+++ b/src/pages/Project/ProjectWrapper.tsx
@@ -244,7 +244,13 @@ const ProjectWrapper: React.FC<ProjectProps> = ({ match }) => {
           title: "Past Correlation Experiments\n",
           description: "Every term, we complete new experiment implementations and data collection. We have completed over 10 different Correlation-related experiments from the original default condition and design, to showing the scatterplots one after the other, and using different symbols, colors and display settings.",
         },
-      ]
+      ],
+      joinTeam: {
+        whatWeDo:[
+          'The Correlation project studies the visual perception of correlation in data visualizations. Data visualization is a graphical representation of a data set. Scatterplots are a simple and common example of visualizing data with two variables. In a scatter plot, data is presented in a graphic form by placing points on a cartesian (x-y) coordinate plane according to their values on each variable. For simple linear data, correlation in a scatter plot corresponds to the degree to which the points form a straight line. ',
+          'Currently we are working on two projects to determine the perception of correlation. The Mainstream Correlation Team studies how manipulating different visual attributes within the scatterplots affect the way we perceive the information shown in the scatterplot, and whether we are able to see Weber and Fechner’s law hold true. The Sequencing Correlation Team studies how different timings for the display duration of the scatterplots or other graphs and symbols used to represent correlation impact its perception. And if Weber\'s law still holds in these conditions where the graphs are shown for only a brief moment of time.'
+        ]
+      }
     },
     {
       name: "NOVA",
@@ -376,7 +382,7 @@ const ProjectWrapper: React.FC<ProjectProps> = ({ match }) => {
         {
           title: "Cueing Using Colour and Isoluminescence: Differences in Blindness Rates and Cueing Effects Between Seen and Unseen Cues",
           description:
-              'Author: Ankita Guha Patra' +
+              'Author: Ankita Guha Patra\n' +
               "Sponsoring Research Assistant Tiffany Wu\n" +
               "Supervisor: Dr. Ronald Rensink\n"
 
@@ -384,7 +390,7 @@ const ProjectWrapper: React.FC<ProjectProps> = ({ match }) => {
         {
           title: "Does Consciousness Matter? Noticeable Edits on Overlearned Cues and the Effect on Blindness Rates and Cueing Effects Between Seen and Unseen Cues",
           description: "Author: Isha Verma\n" +
-              "Spondoring Research Assistant: Ying Zeng\n" +
+              "Sponsoring Research Assistant: Ying Zeng\n" +
               "Supervisor: Dr. Ronald Rensink\n"
         },
       ]

--- a/src/statics/text.ts
+++ b/src/statics/text.ts
@@ -182,7 +182,7 @@ const TEXT = {
       TITLE: "You might like this if you like...",
     },
     PAST_POSITIONS_AND_PROJECTS: {
-      TITLE: "Past Positions and Projects",
+      TITLE: "Past Projects",
       VCL_WEB_APP: {
         TITLE: "VCL Web-App",
         DESCRIPTION:


### PR DESCRIPTION
## Description

uncommented the past projects code in the projectjoin class
created a object in the project interface for pastprojects with a title and a description 
added the pastprojects property to each project object in projectwrapper
still a problem of the nova past project description strings not being able to be seperated into seperate lines


## Updates

[Please enter a brief summary of updates to this PR during code review - if any]

## Checklist

- [ ] Ran `npm run lint:fix` to format code
- [ ] Requested at least one reviewer
- [ ] Connected PR to Trello ticket (steps below)
- [ ] Addressed code review comments
- [ ] Gained at least one approval for your PR

## Connecting your PR to the corresponding ticket:
- Click on the "GitHub" button found on the right of your Trello ticket
- Choose "Attach PR" from the dropdown list
- Link your GitHub account (if you haven't done so already)
- Navigate to`VCL-content-platform` and choose your PR from the dropdown. 