### PR TITLE
Projects Dropdown Resize Bug

### DIFF
--- a/src/components/Navbar/Navbar.css
+++ b/src/components/Navbar/Navbar.css
@@ -23,9 +23,9 @@
 	margin-top: 1.25%;
 }
 
-.dropdown-menu:hover {
+/* .dropdown-menu:hover {
 	max-width: 19%;
-}
+} */
 
 [role=menu] {
 	padding: 20px 35px 35px 35px !important;


### PR DESCRIPTION
## Description

Fixed bug where projects dropdown gets cut off when browser is resized.

## Updates

Changed max-width in CSS, which was causing the dropdown to get cut off.

## Checklist

- [x] Ran `npm run lint:fix` to format code
- [x] Requested at least one reviewer
- [x] Connected PR to Trello ticket (steps below)
- [ ] Addressed code review comments
- [ ] Gained at least one approval for your PR

## Connecting your PR to the corresponding ticket:
- Click on the "GitHub" button found on the right of your Trello ticket
- Choose "Attach PR" from the dropdown list
- Link your GitHub account (if you haven't done so already)
- Navigate to`VCL-content-platform` and choose your PR from the dropdown. 