### PR TITLE
Ryanyae 231 moving hero section

### DIFF
--- a/src/pages/GetInvolved/GetInvolved.css
+++ b/src/pages/GetInvolved/GetInvolved.css
@@ -61,6 +61,7 @@ html {
 
 
 .role-divider {
+    margin-top: 1rem;
 	border: 1.2px solid #8c9fc2;
 }
 

--- a/src/pages/GetInvolved/GetInvolved.css
+++ b/src/pages/GetInvolved/GetInvolved.css
@@ -82,7 +82,7 @@ html {
 .join-main-body {
     text-align: left;
     width: min(80%, 1000px);
-    margin: 48px auto;
+    margin: 2rem auto;
 }
 
 .join-main-body p {

--- a/src/pages/GetInvolved/GetInvolved.css
+++ b/src/pages/GetInvolved/GetInvolved.css
@@ -48,7 +48,6 @@ html {
 
 #info-encapsulate {
     display:relative;
-    padding-top: 2rem;
 }
 
 .join-header * {
@@ -147,6 +146,31 @@ html {
 
 .instruct-summary {
     cursor: pointer;
+}
+
+.project-join-hero-section {
+    padding: 4rem;
+    background-color: #E8EFF6;
+}
+
+.project-join-hero-title-section {
+    max-width: 600px;
+}
+
+.project-join-hero-title-section h2, .project-join-pastProjectSection-section h2{
+    font-size: 1.5rem;
+    color: #8EA9D2;
+}
+
+.project-join-hero-section h1 {
+    color: #4A6999;
+    padding-bottom: 1rem;
+}
+
+.project-join-hero-title-section a {
+    text-decoration: none; /* Removes underline */
+    font-style: normal; /* Ensures the font style is normal */
+    color: white;
 }
 
 @media (max-width: 1023px) {

--- a/src/pages/GetInvolved/GetInvolved.css
+++ b/src/pages/GetInvolved/GetInvolved.css
@@ -155,6 +155,7 @@ html {
 
 .project-join-hero-title-section {
     max-width: 600px;
+    margin: auto;
 }
 
 .project-join-hero-title-section h2, .project-join-pastProjectSection-section h2{

--- a/src/pages/GetInvolved/GetInvolved.tsx
+++ b/src/pages/GetInvolved/GetInvolved.tsx
@@ -141,7 +141,6 @@ const GetInvolved: React.FC<GetInvolvedProps> = props => {
                 </div>
             </div>
 					<div className="join-main-body">
-						<div className='role-divider' />
 						<section ref={pRef}>
 							<h2>Get Involved as a Participant</h2>
 							<p>

--- a/src/pages/GetInvolved/GetInvolved.tsx
+++ b/src/pages/GetInvolved/GetInvolved.tsx
@@ -149,6 +149,7 @@ const GetInvolved: React.FC<GetInvolvedProps> = props => {
 								Sign up for experiments at: <Link to="//www.reservax.com/ubcviscog/" style={{ color: "#5387a5" }} target="_blank" rel="noreferrer">www.reservax.com/ubcviscog/</Link>
 							</p>
 						</section>
+						<div className='role-divider' />
 						<section ref={labMemberRef}>
 							<h2>Get Involved as a Lab Member</h2>
 							<p>

--- a/src/pages/GetInvolved/GetInvolved.tsx
+++ b/src/pages/GetInvolved/GetInvolved.tsx
@@ -118,7 +118,7 @@ const GetInvolved: React.FC<GetInvolvedProps> = props => {
             >
                 <div style={{ maxWidth: '1600px', margin: 'auto', display: 'flex' }}>
                     <div className='project-join-hero-title-section'>
-                        <div style={{ width: 'fit-content', marginBottom: '2rem' }}>
+                        <div style={{ width: 'fit-content', marginBottom:'2rem' }}>
                             <h1>Join Our Team</h1>
                             <div className='project-join-title-bottomBorder'></div>
                         </div>
@@ -129,11 +129,11 @@ const GetInvolved: React.FC<GetInvolvedProps> = props => {
                         <p className='project-join-description'>
                             No background in research is needed, and co-pilots have the flexibility of helping out whenever they want!
                         </p>
-                        <a href={ROUTES.GET_INVOLVED}>
+                        {/* <a href={ROUTES.GET_INVOLVED}>
                             <div className='project-join-joinInstructions-button'>
                                 Application Instructions
                             </div>
-                        </a>
+                        </a> */}
                     </div>
                     <div className='project-join-hero-image-section'>
                         <img src={ResearchIMG} style={{ maxWidth: "500px" }} />

--- a/src/pages/GetInvolved/GetInvolved.tsx
+++ b/src/pages/GetInvolved/GetInvolved.tsx
@@ -8,8 +8,7 @@ import { useRef } from 'react'
 import GetInvolvedSidebar from '@components/GetInvolvedSidebar';
 import { useState, useEffect } from 'react'
 import menuIcon from '@statics/images/menu-icon.png';
-
-
+import ResearchIMG from '@statics/images/JoinTeam/ResearchImage.png';
 
 interface GetInvolvedProps { }
 
@@ -114,10 +113,33 @@ const GetInvolved: React.FC<GetInvolvedProps> = props => {
 					setbarState(!sidebarState)
 				}} /></div>
 				<div id='getInvolvedInfo'>
-					<div className="join-header">
-						<h1>GET INVOLVED</h1>
-						<p className='join-sub-header'>Interested in what we do? Find out how you can join our activities here.</p>
-					</div>
+				<div
+                className='project-join-hero-section'
+            >
+                <div style={{ maxWidth: '1600px', margin: 'auto', display: 'flex' }}>
+                    <div className='project-join-hero-title-section'>
+                        <div style={{ width: 'fit-content', marginBottom: '2rem' }}>
+                            <h1>Join Our Team</h1>
+                            <div className='project-join-title-bottomBorder'></div>
+                        </div>
+                        <p className='project-join-description-bold'>Interested in research? Good news, we’re always looking for new co-pilots. </p>
+                        <p className='project-join-description'>
+                            Co-Pilots sign a contract with the lab that lasts for a school term, with the possibility for renewal. Co-Pilots are assigned to a particular project team based on their interests but have the freedom to explore different projects.
+                        </p>
+                        <p className='project-join-description'>
+                            No background in research is needed, and co-pilots have the flexibility of helping out whenever they want!
+                        </p>
+                        <a href={ROUTES.GET_INVOLVED}>
+                            <div className='project-join-joinInstructions-button'>
+                                Application Instructions
+                            </div>
+                        </a>
+                    </div>
+                    <div className='project-join-hero-image-section'>
+                        <img src={ResearchIMG} style={{ maxWidth: "500px" }} />
+                    </div>
+                </div>
+            </div>
 					<div className="join-main-body">
 						<div className='role-divider' />
 						<section ref={pRef}>

--- a/src/pages/ProjectV2/Pages/Join/ProjectJoinV2.css
+++ b/src/pages/ProjectV2/Pages/Join/ProjectJoinV2.css
@@ -7,7 +7,7 @@
     max-width: 600px;
 }
 
-.project-join-hero-title-section h2, .project-join-pastProjectSection-section h2{
+.project-join-pastProjectSection-section h2{
     font-size: 1.5rem;
     color: #8EA9D2;
 }
@@ -35,7 +35,7 @@
     margin-left: auto;
 }
 
-.project-join-hero-title-section a, .app-instructions-content-section a{
+.app-instructions-content-section a{
     text-decoration: none; /* Removes underline */
     font-style: normal; /* Ensures the font style is normal */
     color: white;

--- a/src/pages/ProjectV2/Pages/Join/ProjectV2Join.tsx
+++ b/src/pages/ProjectV2/Pages/Join/ProjectV2Join.tsx
@@ -1,5 +1,4 @@
 import './ProjectJoinV2.css';
-import ResearchIMG from '@statics/images/JoinTeam/ResearchImage.png';
 import { TEXT, ROUTES } from "@statics";
 import PROJECT_TEXT, { PROJECT } from "@statics/projectsV2";
 import visualAttention from '@statics/images/JoinTeam/visualAttention.png';
@@ -29,37 +28,10 @@ const ProjectV2Join = (props: PropsOBJ) => {
 
     return (
         <div >
-            <div
-                className='project-join-hero-section'
-            >
-                <div style={{ maxWidth: '1600px', margin: 'auto', display: 'flex' }}>
-                    <div className='project-join-hero-title-section'>
-                        <h2>01</h2>
-                        <div style={{ width: 'fit-content', marginBottom: '2rem' }}>
-                            <h1>Join Our Team</h1>
-                            <div className='project-join-title-bottomBorder'></div>
-                        </div>
-                        <p className='project-join-description-bold'>Interested in research? Good news, we’re always looking for new co-pilots. </p>
-                        <p className='project-join-description'>
-                            Co-Pilots sign a contract with the lab that lasts for a school term, with the possibility for renewal. Co-Pilots are assigned to a particular project team based on their interests but have the freedom to explore different projects.
-                        </p>
-                        <p className='project-join-description'>
-                            No background in research is needed, and co-pilots have the flexibility of helping out whenever they want!
-                        </p>
-                        <a href={ROUTES.GET_INVOLVED}>
-                            <div className='project-join-joinInstructions-button'>
-                                Application Instructions
-                            </div>
-                        </a>
-                    </div>
-                    <div className='project-join-hero-image-section'>
-                        <img src={ResearchIMG} style={{ maxWidth: "500px" }} />
-                    </div>
-                </div>
-            </div>
+            
 
             <div className='project-join-whatWeDo-section'>
-                <h2>02</h2>
+                <h2>01</h2>
                 <h1>What We Do</h1>
                 {
                     currentProject?.joinTeam.whatWeDo.map((item, index) => {
@@ -85,7 +57,7 @@ const ProjectV2Join = (props: PropsOBJ) => {
             <div
                 className='project-join-pastProjectSection-section'
             >
-                <h2>03</h2>
+                <h2>02</h2>
                 <h1>Past Projects</h1>
                 {
                     currentProject?.pastProjects?.map((item, index) => {
@@ -104,12 +76,12 @@ const ProjectV2Join = (props: PropsOBJ) => {
             <div
                 className='project-join-testimony-section'
             >
-                <ProjectGallery2 data={currentProject!.testimonials!} title='What our team members say...' titleNum='04' darkmode={true} />
+                <ProjectGallery2 data={currentProject!.testimonials!} title='What our team members say...' titleNum='03' darkmode={true} />
             </div>
             <div
                 className='project-join-applicationInstructions-section'
             >
-                <h2>05</h2>
+                <h2>04</h2>
                 <h1>Application Instructions</h1>
                 <div style={{ backgroundColor: 'white', width: '30%', padding: '2rem', margin: 'auto', marginTop: '3rem', minWidth:'300px',maxWidth:'500px' }}>
                     <div className="app-instructions-title-section" style={{ display: 'flex', width: 'fit-content' }}>


### PR DESCRIPTION
## Description

Moved hero section of ProjectV2Join to be the new hero section of getInvolved.

## Updates

I have some concerns tho:
- How should we be repurposing the "Application Instruction" button? 
![image](https://github.com/UBC-VCL/VCL-content-platform/assets/76890786/b362ddc7-a7c8-4955-9129-aa6d540a2048)
- It currently redirects the user to the GetInvolved page
- Secondly, I think we should think about making the sidebar un-collapsable, the new ProjectPages have an un-collapsable sidebar and I believe making this feature universal maybe for the better.

## Checklist

- [ ] Ran `npm run lint:fix` to format code
- [x] Requested at least one reviewer
- [ ] Connected PR to Trello ticket (steps below)
- [ ] Addressed code review comments
- [ ] Gained at least one approval for your PR

## Connecting your PR to the corresponding ticket:
- Click on the "GitHub" button found on the right of your Trello ticket
- Choose "Attach PR" from the dropdown list
- Link your GitHub account (if you haven't done so already)
- Navigate to`VCL-content-platform` and choose your PR from the dropdown. 